### PR TITLE
:wrench: Enhance generator notation

### DIFF
--- a/lectures/3-ec.tex
+++ b/lectures/3-ec.tex
@@ -181,7 +181,7 @@ The non-zero elements of $\mathbb{F}_p$, denoted as $\mathbb{F}_p^{\times}$, for
     \mathbb{F}_p^{\times} = \{g^k: 0 \leq k \leq p-2\}
 \end{equation}
 
-The order of $g \in \mathbb{F}_p^{\times}$ is the smallest positive integer $r$ such that $g^r=1$. It is also not difficult to show that $r \mid (q-1)$.
+The order of $x \in \mathbb{F}_p^{\times}$ is the smallest positive integer $r$ such that $x^r=1$. It is also not difficult to show that $r \mid (p-1)$.
 
 \begin{definition}
     $\omega \in \mathbb{F}$ is the \textit{primitive root} in the finite field $\mathbb{F}$ if $\langle\omega\rangle = \mathbb{F}^{\times}$.
@@ -517,6 +517,5 @@ Now, if the curve is ``good'', then the discrete logarithm problem is hard. In f
     \item $O(\sqrt{\min\{q,r\}})$
     \item $O(\max\{q,r\})$
 \end{enumerate}
-
 
 \end{document}

--- a/lectures/3-ec.tex
+++ b/lectures/3-ec.tex
@@ -176,9 +176,9 @@ Now, in the subsequent sections, we would need to extend $\mathbb{F}_p$ at least
 
 \subsubsection{Multiplicative Group of a Finite Field}
 
-The non-zero elements of $\mathbb{F}_p$, denoted as $\mathbb{F}_p^{\times}$, form a multiplicative cyclic group. In other words, there exist elements $f \in \mathbb{F}_p^{\times}$, called \textit{generators}, such that
+The non-zero elements of $\mathbb{F}_p$, denoted as $\mathbb{F}_p^{\times}$, form a multiplicative cyclic group. In other words, there exist elements $g \in \mathbb{F}_p^{\times}$, called \textit{generators}, such that
 \begin{equation}
-    \mathbb{F}_p^{\times} = \{f^k: 0 \leq k \leq p-2\}
+    \mathbb{F}_p^{\times} = \{g^k: 0 \leq k \leq p-2\}
 \end{equation}
 
 The order of $g \in \mathbb{F}_p^{\times}$ is the smallest positive integer $r$ such that $g^r=1$. It is also not difficult to show that $r \mid (q-1)$.


### PR DESCRIPTION
## Changes

* The $f$ notation for a generator is a bit confusing, as usually, and below, the $g$ notation is used for generators.

Before:
<img width="817" alt="image" src="https://github.com/user-attachments/assets/ef6c6689-cb70-4844-a2e1-097ea3e554e5">

After:
<img width="813" alt="image" src="https://github.com/user-attachments/assets/ea631885-035e-4ea9-ac37-45017c100d26">
